### PR TITLE
Fix a bug that causes an XmlRpc::XmlRpcException

### DIFF
--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -484,6 +484,11 @@ bool TopicManager::registerSubscriber(const SubscriptionPtr& s, const string &da
     return false;
   }
 
+  if (payload.getType() == XmlRpcValue::TypeInvalid)
+  {
+    return false;
+  }
+
   vector<string> pub_uris;
   for (int i = 0; i < payload.size(); i++)
   {


### PR DESCRIPTION
The exception is raised  if the node is trying to subscribe to a topic after rosmaster dies. In this case,  the node will be stuck in an infinite loop in `ros::master::execute()`:

https://github.com/ros/ros_comm/blob/kinetic-devel/clients/roscpp/src/libros/master.cpp#L189

When the node is sent a sigint, it will exit this loop and `execute()` will return with an invalid `payload` that causes the exception when trying to do `payload.size()`.

A simple example to reproduce:

```
#include "ros/ros.h"
#include "std_msgs/String.h"
#include <ros/topic.h>

void callback(const std_msgs::String::ConstPtr& msg)
{
  ROS_ERROR(msg->data.c_str());
}

int main(int argc, char **argv)
{
  ros::init(argc, argv, "test_node");
  ros::NodeHandle n;

  boost::shared_ptr<std_msgs::String const> msg;
  while (!(msg = ros::topic::waitForMessage<std_msgs::String>("some_topic", n, ros::Duration(2))) && ros::ok())
  {
    ROS_ERROR("Waiting for messages");
  }
  
  ros::spin();
  return 0;
}
```

If we run roscore, then run the above node, then kill roscore then try to stop the node with Ctrl-C we will get:
` terminate called after throwing an instance of ' XmlRpc::XmlRpcException'`

An alternative solution would be to add at the end of `ros::master::execute()` before `return true`:
```
if (!ros::ok())
{
  return false;
}
return true;
```